### PR TITLE
Refactor BarChart with DrawScope functions

### DIFF
--- a/charty/src/main/java/com/himanshoe/charty/bar/BarChart.kt
+++ b/charty/src/main/java/com/himanshoe/charty/bar/BarChart.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import com.himanshoe.charty.bar.common.calculations.getTopLeft
 import com.himanshoe.charty.bar.common.calculations.getTopRight
@@ -61,51 +63,84 @@ fun BarChart(
     barConfig: BarConfig = BarConfigDefaults.barConfigDimesDefaults()
 ) {
     val maxYValueState = rememberSaveable { mutableStateOf(barData.maxYValue()) }
-    val clickedBar = remember { mutableStateOf(Offset(-10F, -10F)) }
+    val clickedBarState = remember { mutableStateOf(Offset(-10F, -10F)) }
+    val barWidthState = remember { mutableStateOf(0F) }
 
-    val maxYValue = maxYValueState.value
-    val barWidth = remember { mutableStateOf(0F) }
-
-    Canvas(
-        modifier = modifier
+    Canvas(modifier = modifier
+            // draw axis in background
             .drawBehind {
                 if (axisConfig.showAxis) {
-                    drawYAxisWithLabels(
+                    barChartBackground(
                         axisConfig = axisConfig,
-                        maxValue = maxYValue,
-                        textColor = axisConfig.textColor
+                        maxYValue = maxYValueState.value,
                     )
                 }
             }
+            // add padding to canvas
             .padding(horizontal = chartDimens.padding)
             .pointerInput(Unit) {
                 detectTapGestures(onPress = { offset ->
-                    clickedBar.value = offset
+                    clickedBarState.value = offset
                 })
             }
     ) {
-        barWidth.value = size.width.div(barData.count().times(1.2F))
-        val yScalableFactor = size.height.div(maxYValue)
+        barWidthState.value =
+            barChart(
+                barData = barData,
+                colors = colors,
+                onBarClick = onBarClick,
+                axisConfig = axisConfig,
+                barConfig = barConfig,
+                clickedBar = clickedBarState.value,
+                maxYValue = maxYValueState.value
+            )
+    }
+}
+
+fun DrawScope.barChartBackground(
+    axisConfig: AxisConfig,
+    maxYValue: Float,
+) {
+    drawYAxisWithLabels(
+        axisConfig = axisConfig,
+        maxValue = maxYValue,
+        textColor = axisConfig.textColor
+    )
+}
+
+fun DrawScope.barChart(
+    barData: List<BarData>,
+    colors: List<Color>,
+    onBarClick: (BarData) -> Unit,
+    axisConfig: AxisConfig,
+    barConfig: BarConfig,
+    clickedBar: Offset,
+    maxYValue: Float,
+) : Float {
+    val barWidth = size.width.div(barData.count().times(1.2F))
+    val yScalableFactor = size.height.div(maxYValue)
+
+    drawIntoCanvas {
 
         barData.forEachIndexed { index, data ->
-            val topLeft = getTopLeft(index, barWidth.value, size, data.yValue, yScalableFactor)
-            val topRight = getTopRight(index, barWidth.value, size, data.yValue, yScalableFactor)
+            val topLeft = getTopLeft(index, barWidth, size, data.yValue, yScalableFactor)
+            val topRight = getTopRight(index, barWidth, size, data.yValue, yScalableFactor)
             val barHeight = data.yValue.times(yScalableFactor)
 
-            if (clickedBar.value.x in (topLeft.x..topRight.x)) {
+            if (clickedBar.x in (topLeft.x..topRight.x)) {
                 onBarClick(data)
             }
             drawRoundRect(
                 cornerRadius = CornerRadius(if (barConfig.hasRoundedCorner) barHeight else 0F),
                 topLeft = topLeft,
                 brush = Brush.linearGradient(colors),
-                size = Size(barWidth.value, barHeight)
+                size = Size(barWidth, barHeight)
             )
 
             if (axisConfig.showXLabels) {
                 drawBarLabel(
                     data.xValue,
-                    barWidth.value,
+                    barWidth,
                     barHeight,
                     topLeft,
                     barData.count(),
@@ -114,4 +149,5 @@ fun BarChart(
             }
         }
     }
+    return barWidth
 }


### PR DESCRIPTION
Thanks for the great work to make this fantastic charty library.
It would be really great if the charty can refactor all the charts composable function into useful `DrawScope` function.

This will be a fantastic feature to make dynamic graphs for `Wear OS 3 by google Material Tiles` with the horologist lib (https://github.com/google/horologist). 

The most open source compose chart libs are strictly depends on `Canvas composable`, if `Charty` can ease this dependency. It can become a valuable compose chart lib to make dynamic Tile charts for millions of potential Wear OS Material Tiles apps.     