### PR TITLE
Fixes state issues with remembering

### DIFF
--- a/charty/src/main/java/com/himanshoe/charty/bar/BarChart.kt
+++ b/charty/src/main/java/com/himanshoe/charty/bar/BarChart.kt
@@ -5,9 +5,10 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
@@ -60,10 +61,12 @@ fun BarChart(
     axisConfig: AxisConfig = AxisConfigDefaults.axisConfigDefaults(isSystemInDarkTheme()),
     barConfig: BarConfig = BarConfigDefaults.barConfigDimesDefaults()
 ) {
-    val maxYValueState = rememberSaveable { mutableStateOf(barData.maxYValue()) }
+    val maxYValue by remember(barData) {
+        derivedStateOf {
+            barData.maxYValue()
+        }
+    }
     val clickedBar = remember { mutableStateOf(Offset(-10F, -10F)) }
-
-    val maxYValue = maxYValueState.value
     val barWidth = remember { mutableStateOf(0F) }
 
     Canvas(


### PR DESCRIPTION
This should fix an issue with incorrect state being displayed through updates. I'll likely have to make this change in several places in order to fix the issue through out the library, the same unstable pattern seems to be repeated.

To expand a little on why _i think_ the issue is occurring: Since `remember` did not take in a key it was still operating on the old `barData`. I imagine if `barData` was a `@Stable` class then your original code would have worked. 

If this change is fine with you, I can make the appropriate changes in other parts of the library as well.

### Old
[device-2023-02-16-110449.webm](https://user-images.githubusercontent.com/3111880/219422230-f6cb2e98-07cf-4ec0-a042-b509a99303bf.webm)

### New
[device-2023-02-16-110526.webm](https://user-images.githubusercontent.com/3111880/219422593-4d93d28b-dbd7-4ed0-9593-c4a10a84f0b4.webm)



